### PR TITLE
Dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ project(hash-dumper
     HOMEPAGE_URL "https://github.com/Retr0-code/hash-dumper"
 )
 
+# set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fshort-wchar")
+add_compile_options(-fshort-wchar)
+
 set(EXEC_SRC
     src/main.c
     src/hive.c

--- a/src/arg_parser.c
+++ b/src/arg_parser.c
@@ -60,7 +60,7 @@ const argument_t* arg_init_arg(arg_type type, const char* key, const char* descr
     if (key == NULL || description == NULL)
     {
         errno = EINVAL;
-        return arg_invalid_arg;
+        return NULL;
     }
 
     argument_t* arg_ptr = malloc_check(arg_ptr, sizeof(argument_t), NULL);
@@ -118,7 +118,7 @@ argument_t *arg_get(const char *key, arg_parser_t *parser_ptr)
     if (key == NULL || parser_ptr == NULL)
     {
         errno = EINVAL;
-        return arg_invalid_arg;
+        return NULL;
     }
 
     return ht_get_elem(key, parser_ptr->arguments);
@@ -127,7 +127,7 @@ argument_t *arg_get(const char *key, arg_parser_t *parser_ptr)
 int arg_parse(int argc, const char **argv, arg_parser_t *parser_ptr)
 {
     // Validating parameters
-    if (argc == 0 || argc == NULL || parser_ptr == NULL)
+    if (argc == 0 || argv == NULL || parser_ptr == NULL)
     {
         errno = EINVAL;
         return arg_invalid_arg;

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -57,7 +57,7 @@ uint8_t* get_md5(const char* data, size_t data_size)
 	return raw_hash;
 }
 
-int rc4_encrypt(const uint8_t* data, size_t data_len, uint8_t* key, uint8_t* enc_data)
+int rc4_encrypt(const uint8_t* data, int data_len, uint8_t* key, uint8_t* enc_data)
 {
 	// Loading legacy algorithms provider
 	OSSL_PROVIDER* legacy = OSSL_PROVIDER_load(NULL, "legacy");

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -43,7 +43,7 @@
 uint8_t* get_md5(const char* data, size_t data_size);
 
 // Encrypts RC4
-int rc4_encrypt(const uint8_t* data, size_t data_len, uint8_t* key, uint8_t* enc_data);
+int rc4_encrypt(const uint8_t* data, int data_len, uint8_t* key, uint8_t* enc_data);
 
 // Decryps AES 128 CBC
 int aes_128_cbc_decrypt(

--- a/src/dump_bootkey.c
+++ b/src/dump_bootkey.c
@@ -112,7 +112,7 @@ int dump_bootkey(FILE* sys_hive, wchar_t* out_bootkey)
     }
 
     out_bootkey[RAW_BOOTKEY_LENGTH * 2] = L'\0';
-    
+
     for (size_t i = 0; i < RAW_BOOTKEY_LENGTH * 2; i++)
         out_bootkey[i] = towupper(out_bootkey[i]);
 

--- a/src/dump_hashes.c
+++ b/src/dump_hashes.c
@@ -107,7 +107,7 @@ int dump_users_keys(FILE* sam_hive, named_key_t** users_keys_array, size_t* user
         -9, 5,
         hive_header_ptr, base_nk_ptr, users_nk_ptr, reg_users_path, hints
     );
-    memset(*users_keys_array, NULL, subkey_list.elements_amount * sizeof(named_key_t));
+    memset(*users_keys_array, 0, subkey_list.elements_amount * sizeof(named_key_t));
     *users_amount = 0;
 
     // Iterate throug all Users subkeys
@@ -303,7 +303,13 @@ int decrypt_ntlm_hash(ntlm_user_t* user_info_ptr, const uint8_t* hashed_bootkey,
     return 0;
 }
 
-int decrypt_hash(uint8_t* enc_hash, uint8_t* hashed_bootkey, uint8_t* ntlmphrase, ntlm_user_t* user_info_ptr, uint8_t* decrypted_hash)
+int decrypt_hash(
+    const uint8_t* enc_hash,
+    const uint8_t* hashed_bootkey,
+    const uint8_t* ntlmphrase,
+    ntlm_user_t* user_info_ptr,
+    uint8_t* decrypted_hash
+)
 {
     // Validating parameters
     if (enc_hash == NULL || hashed_bootkey == NULL || ntlmphrase == NULL || user_info_ptr == NULL || decrypted_hash == NULL)
@@ -355,7 +361,13 @@ int decrypt_hash(uint8_t* enc_hash, uint8_t* hashed_bootkey, uint8_t* ntlmphrase
     return 0;
 }
 
-int decrypt_salted_hash(uint8_t* enc_hash, uint8_t* hashed_bootkey, uint8_t* salt, ntlm_user_t* user_info_ptr, uint8_t* decrypted_hash)
+int decrypt_salted_hash(
+    const uint8_t* enc_hash,
+    const uint8_t* hashed_bootkey,
+    const uint8_t* salt,
+    ntlm_user_t* user_info_ptr,
+    uint8_t* decrypted_hash
+)
 {
     // Validating parameters
     if (enc_hash == NULL || hashed_bootkey == NULL || salt == NULL || user_info_ptr == NULL || decrypted_hash == NULL)

--- a/src/dump_hashes.h
+++ b/src/dump_hashes.h
@@ -66,18 +66,18 @@ int decrypt_ntlm_hash(ntlm_user_t* user_info_ptr, const uint8_t* hashed_bootkey,
 
 // Decrypts non-salted/NTLMv1 hash
 int decrypt_hash(
-	uint8_t* enc_hash,
-	uint8_t* hashed_bootkey,
-	uint8_t* ntlmphrase,
+	const uint8_t* enc_hash,
+	const uint8_t* hashed_bootkey,
+	const uint8_t* ntlmphrase,
 	ntlm_user_t* user_info_ptr,
 	uint8_t* decrypted_hash
 );
 
 // Decrypts salted/NTLMv2 hash
 int decrypt_salted_hash(
-	uint8_t* enc_hash,
-	uint8_t* hashed_bootkey,
-	uint8_t* salt,
+	const uint8_t* enc_hash,
+	const uint8_t* hashed_bootkey,
+	const uint8_t* salt,
 	ntlm_user_t* user_info_ptr,
 	uint8_t* decrypted_hash
 );

--- a/src/dump_hives.c
+++ b/src/dump_hives.c
@@ -154,8 +154,6 @@ void set_paths(const char* sys_hive_path, const char* sam_hive_path)
 
 	strcpy(system_hive_filepath, sys_hive_path);
 	strcpy(sam_hive_filepath, sam_hive_path);
-	// system_hive_filepath = sys_hive_path;
-	// sam_hive_filepath = sam_hive_path;
 }
 
 int open_hives(FILE** system_hive, FILE** sam_hive)
@@ -184,6 +182,4 @@ void close_hives(FILE** system_hive, FILE** sam_hive, int delete_hives)
 		remove(system_hive_filepath);
 		remove(sam_hive_filepath);
 	}
-
-	return 0;
 }

--- a/src/dump_hives.c
+++ b/src/dump_hives.c
@@ -165,7 +165,7 @@ int open_hives(FILE** system_hive, FILE** sam_hive)
 	*sam_hive = fopen(sam_hive_filepath, "rb");
 	if (*sam_hive == NULL)
 	{
-		fclose(system_hive);
+		fclose(*system_hive);
 		return -2;
 	}
 

--- a/src/functional.c
+++ b/src/functional.c
@@ -31,11 +31,11 @@ char* get_random_string(size_t length)
 	if (length == 0)
 	{
 		errno = EINVAL;
-		return -1;
+		return NULL;
 	}
 
 	// Allocating string
-	char* str = malloc_check(str, length + 1, -2);
+	char* str = malloc_check(str, length + 1, NULL);
 	srand(time(NULL));
 
 	// Generating string

--- a/src/main.c
+++ b/src/main.c
@@ -31,6 +31,7 @@
 #define IS_WINDOWS 0
 #endif
 
+
 #define PROGRAM_INFO    \
 "hash-dumper is utility for dumping NTLMv1/2 hashes from windows registry hives SAM and SYSTEM. \
 It can be used in realtime dumping mode, when hives will be dumped to temp files and then deleted, \


### PR DESCRIPTION
# Bugfix Cleanup warnings

## Issues

 - Casting away *const* from some pointers;
 - Returning inappropriate values;
 - GCC and Clang by default use 4-byte wchar_t;

### Related issues

 - https://github.com/Retr0-code/hash-dumper/issues/3

## Description

Fixed some compilation warnings. Started working on linux support.

## Solution

 - Removed places, where *const* were casted away;
 - Fixed return values in some functions;
 - Added 2-byte wchar_t option to CMakeLists.txt;
