### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ hash_dumper.vcxproj.filters
 hash_dumper.vcxproj.user
 x64/
 Debug/
+Release/
 hives
 build
 .vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,51 @@
 cmake_minimum_required(VERSION 3.16.0)
 
-project(hash-dumper
-    VERSION 0.1
+project(hash_dumper
+    VERSION 1.0.3
     DESCRIPTION "Windows NTLM hash dumper"
     HOMEPAGE_URL "https://github.com/Retr0-code/hash-dumper"
 )
 
+# Initializing parameters
+option(DEBUG "Sets compilation flags for debugging" OFF)
+option(RELEASE "Sets compilation flags for optimized binary" OFF)
+option(BUILD32 "Sets compilation flags for 32-bit mode" OFF)
+set(INSTALL_PREFIX /usr/local/bin CACHE PATH "Path for installed binaries")
+
+# Checking parameters
+set(CMAKE_INSTALL_PREFIX ${INSTALL_PREFIX})
+
+if ((DEBUG) AND (NOT RELEASE))
+    if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
+        add_compile_options(-O0)
+        add_compile_options(-ggdb)
+
+    elseif (CMAKE_C_COMPILER_ID STREQUAL "Clang")
+        add_compile_options(-O0)
+        add_compile_options(-g)
+
+    else()
+        message(FATAL_ERROR "Unknown compiler ${CMAKE_C_COMPILER_ID}")
+    endif()
+
+    message(STATUS "Enabled debug mode")
+
+endif()
+
+if ((NOT DEBUG) AND (RELEASE))
+    message(STATUS "Enabled release with -O3")
+    add_compile_options(-O3)
+endif()
+
+if (BUILD32)
+    message(STATUS "Enabled 32-bit mode")
+    add_compile_options(-m32)
+    add_link_options(-m32)
+    SET(CMAKE_LIBRARY_PATH "/usr/lib/i386-linux-gnu")
+    include_directories(BEFORE /usr/include/i386-linux-gnu)
+endif()
+
+# Source code paths
 set(EXEC_SRC
     src/main.c
     src/hive.c
@@ -18,9 +58,31 @@ set(EXEC_SRC
     src/string-hashtable/hash_table.c
     )
 
+# Link openssl and build executable
 set(OPENSSL_USE_STATIC_LIBS TRUE)
 find_package(OpenSSL REQUIRED)
 
 add_executable(${PROJECT_NAME} ${EXEC_SRC})
 target_link_libraries(${PROJECT_NAME} OpenSSL::SSL)
 target_link_libraries(${PROJECT_NAME} OpenSSL::Crypto)
+
+install(TARGETS ${PROJECT_NAME} DESTINATION .)
+message(STATUS "WARNING! Installation prefix ${CMAKE_INSTALL_PREFIX}")
+
+# Cleanup cache
+unset(DEBUG CACHE)
+unset(RELEASE CACHE)
+unset(BUILD32 CACHE)
+unset(INSTALL_PREFIX CACHE)
+
+unset(CMAKE_LIBRARY_PATH CACHE)
+unset(CMAKE_INSTALL_PREFIX CACHE)
+
+unset(OPENSSL_FOUND CACHE)
+unset(OPENSSL_INCLUDE_DIR CACHE)
+unset(OPENSSL_CRYPTO_LIBRARY CACHE)
+unset(OPENSSL_CRYPTO_LIBRARIES CACHE)
+unset(OPENSSL_SSL_LIBRARY CACHE)
+unset(OPENSSL_SSL_LIBRARIES CACHE)
+unset(OPENSSL_LIBRARIES CACHE)
+unset(OPENSSL_VERSION CACHE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # [NTLMv1/2 Hash Dumper](https://github.com/Retr0-code/hash-dumper)
 
-Windows NTLM hash dumper utility written in C language. It has support for Windows realtime dumping and Linux dumping from files.
+Windows NTLM hash dumper utility written in C language, that supports Windows and Linux.
+
+**Hash dumper** has got 2 modes:
+ - *Realtime mode* (only for windows);
+ - *Extraction mode* (dumps from saved SAM and SYSTEM hives files);
 
 [![GitHub issues](https://img.shields.io/github/issues/Retr0-code/hash-dumper?labelColor=44E26E&color=505050)](https://github.com/Retr0-code/hash-dumper/issues?q=is%3Aopen+is%3Aissue)
 [![GitHub closed issues](https://img.shields.io/github/issues-closed/Retr0-code/hash-dumper?labelColor=40D668&color=505050)](https://github.com/Retr0-code/hash-dumper/issues?q=is%3Aissue+is%3Aclosed)
@@ -10,7 +14,7 @@ Windows NTLM hash dumper utility written in C language. It has support for Windo
 [![GitHub License](https://img.shields.io/github/license/Retr0-code/hash-dumper?labelColor=6967A6&color=505050)](https://github.com/Retr0-code/hash-dumper/blob/main/LICENSE.txt)
 [![GitHub commit activity (branch)](https://img.shields.io/github/commit-activity/t/Retr0-code/hash-dumper?labelColor=525182&color=505050)](https://github.com/Retr0-code/hash-dumper/commits/main)
 
-![Linux support](https://img.shields.io/badge/Linux-Unsupported-505050?labelColor=8C0842)
+![Linux support](https://img.shields.io/badge/Linux-Supported-505050?labelColor=8C0842)
 ![NTLMv1](https://img.shields.io/badge/NTLMv1-Supported-505050?labelColor=B00B53)
 ![NTLMv2](https://img.shields.io/badge/NTLMv2-Supported-505050?labelColor=DE0D68)
 
@@ -27,9 +31,9 @@ The author is not responsible for the actions of third parties committed while u
 
 ## Compilation
 
-For compilation required *OpenSSL >= 3.0 or OpenSSL 1.1.1* library. Use cmake to generate a solution for Visual Studio or Make file. Cmake requires **OPENSSL_ROOT_DIR** and **OPENSSL_LIB** variables to be set.
+For compilation required *OpenSSL >= 3.0 or OpenSSL 1.1.1* library. Use cmake to generate a solution for Visual Studio or Make file. If CMake cannot find OpenSSL, than set **OPENSSL_ROOT_DIR** and **OPENSSL_LIB_DIR** variables.
 
-**If You have chosen OpenSSL >= 3.0 You have to compile legacy provider for RC4 and DES**
+**If OpenSSL >= 3.0 was chosen, than legacy provider have to be compiled for RC4 and DES**
 
  - [Compiling OpenSSL for Windows](https://wiki.openssl.org/index.php/Compilation_and_Installation)
  - [Running CMake with OpenSSL](https://stackoverflow.com/a/45548831)


### PR DESCRIPTION
# New feature

## What's new

### Related Issues

 - https://github.com/Retr0-code/hash-dumper/issues/16

### Description

 Added new options to CMakeLists.txt

 - *BUILD32* builds 32-bit version; requires OpenSSL:i386;
 - *INSTALL_PREFIX* sets path to installed binary;
 - *RELEASE* enables release configuration;
 - *DEBUG* enables debug configuration;

